### PR TITLE
fix CORS for Vercel frontend

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -472,7 +472,7 @@ async fn main() -> std::io::Result<()> {
         let cors = Cors::default()
             .allowed_origin("http://localhost:3000")
             .allowed_origin("http://127.0.0.1:3000")
-            .allowed_origin("https://code-connect-eta-ecru.vercel.app/")
+            .allowed_origin("https://code-connect-eta-ecru.vercel.app")
             .allowed_methods(vec!["GET", "POST", "OPTIONS"])
             .allowed_headers(vec!["Content-Type", "Authorization"])
             .max_age(3600);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed CORS by removing the trailing slash from the Vercel frontend origin, allowing https://code-connect-eta-ecru.vercel.app to access the API without CORS errors.

<sup>Written for commit c29a5389adf55e1685cd4f3009e35f20308f8456. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

